### PR TITLE
Agrega funcionalidad en cargar-linea

### DIFF
--- a/src/basic.clj
+++ b/src/basic.clj
@@ -825,14 +825,19 @@
     (> (first linea-x) (first linea-y))    
 )
 
+; Devuelve si la linea-x tiene nro-linea igual a la linea-y
+(defn coincide-nro-linea [linea-x linea-y]
+    (= (first linea-x) (first linea-y))
+)
+
 (defn cargar-linea [linea amb]
-    (let [
-        lineas-menores (filter (partial se-ejecuta-despues linea) (first amb))
-        lineas-mayores (filter (partial se-ejecuta-antes linea) (first amb))
-        nuevas-lineas (concat lineas-menores (cons linea '()) lineas-mayores)
-    ]
-    (vec (cons nuevas-lineas (rest amb)))
-    )
+    (let [lineas-menores (filter (partial se-ejecuta-despues linea) (first amb))
+          lineas-mayores (filter (partial se-ejecuta-antes linea) (first amb))
+          linea-vieja (first (filter (partial coincide-nro-linea linea) (first amb)))
+          nuevas-lineas (if (or (> (count linea) 1) (nil? linea-vieja))
+                            (concat lineas-menores (cons linea '()) lineas-mayores)
+                            (concat lineas-menores lineas-mayores))]
+        (vec (cons nuevas-lineas (rest amb))))
 )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/test.clj
+++ b/test/test.clj
@@ -140,6 +140,8 @@
 	(is (= '[((10 (PRINT X)) (20 (X = 100))) [:ejecucion-inmediata 0] [] [] [] 0 {}] (cargar-linea '(20 (X = 100)) ['((10 (PRINT X))) [:ejecucion-inmediata 0] [] [] [] 0 {}])))
 	(is (= '[((10 (PRINT X)) (15 (X = X + 1)) (20 (X = 100))) [:ejecucion-inmediata 0] [] [] [] 0 {}] (cargar-linea '(15 (X = X + 1)) ['((10 (PRINT X)) (20 (X = 100))) [:ejecucion-inmediata 0] [] [] [] 0 {}])))
 	(is (= '[((10 (PRINT X)) (15 (X = X - 1)) (20 (X = 100))) [:ejecucion-inmediata 0] [] [] [] 0 {}] (cargar-linea '(15 (X = X - 1)) ['((10 (PRINT X)) (15 (X = X + 1)) (20 (X = 100))) [:ejecucion-inmediata 0] [] [] [] 0 {}])))
+	(is (= '[((10 (PRINT X)) (20 (X = 100)) (30)) [:ejecucion-inmediata 0] [] [] [] 0 {}] (cargar-linea '(30) ['((10 (PRINT X)) (20 (X = 100))) [:ejecucion-inmediata 0] [] [] [] 0 {}])))
+	(is (= '[((10 (PRINT X)) (20 (X = 100))) [:ejecucion-inmediata 0] [] [] [] 0 {}] (cargar-linea '(30) ['((10 (PRINT X)) (20 (X = 100)) (30)) [:ejecucion-inmediata 0] [] [] [] 0 {}])))
 )
 
 (deftest test-es-next?


### PR DESCRIPTION
La funcionalidad es: quitar una línea del ambiente en caso de que carezca de sentencia.